### PR TITLE
Implement embedding with NNC IR

### DIFF
--- a/test/cpp/tensorexpr/test_ops.cpp
+++ b/test/cpp/tensorexpr/test_ops.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
 #include <torch/csrc/jit/tensorexpr/expr.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
@@ -75,4 +76,44 @@ TEST(Ops, ChannelsLastSum) {
 
     ASSERT_TRUE(at::allclose(bt, ref));
   }
+}
+
+TEST(Ops, Embedding) {
+  const auto graph_string = R"IR(
+    graph(%embedding_weight : Float(10000, 300, strides=[300, 1], device=cpu),
+          %indices : Long(2, 4, strides=[4, 1], device=cpu)):
+      %padding_idx : int = prim::Constant[value=-1]()
+      %1 : int = prim::Constant[value=1]()
+      %2 : bool = prim::Constant[value=0]()
+      %3 : Float(2, 4, 300, strides=[1200, 300, 1], requires_grad=0, device=cpu) = aten::embedding(%embedding_weight, %indices, %padding_idx, %2, %2)
+      %4 : Float(2, 4, 300, strides=[1200, 300, 1], requires_grad=0, device=cpu) = aten::add(%3, %3, %1)
+      %5 : Float(2, 4, 300, strides=[1200, 300, 1], requires_grad=0, device=cpu) = aten::mul(%4, %4)
+      return (%5))IR";
+
+  auto graph = std::make_shared<torch::jit::Graph>();
+  parseIR(graph_string, &*graph);
+
+  auto indices =
+      at::randint(10, {2, 4}, at::TensorOptions(c10::kCPU).dtype(at::kLong));
+  auto embedding_weight =
+      at::rand({10000, 300}, at::TensorOptions(c10::kCPU).dtype(at::kFloat));
+  auto y_1 = at::embedding(embedding_weight, indices);
+  auto y_2 = at::add(y_1, y_1, 1);
+  auto y_expected = at::mul(y_2, y_2);
+
+  TensorExprKernel k(graph);
+  std::vector<at::Tensor> inputs = {embedding_weight, indices};
+
+  std::vector<c10::IValue> stack = at::fmap<c10::IValue>(inputs);
+  k.run(stack);
+  auto y = stack[0].toTensor();
+
+  bool check = at::allclose(y_expected, y);
+  if (!check) {
+    std::cout << "indices:\n" << indices << std::endl;
+    std::cout << "embedding_weight:\n" << embedding_weight << std::endl;
+    std::cout << "y_expected:\n" << y_expected << std::endl;
+    std::cout << "y:\n" << y << std::endl;
+  }
+  TORCH_CHECK_EQ(check, 1);
 }

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -101,6 +101,7 @@ bool isSupported(Node* node) {
   static const OperatorSet supported_misc_set{
       "aten::cat(Tensor[] tensors, int dim=0) -> Tensor",
       "aten::unsqueeze(Tensor(a) self, int dim) -> Tensor(a)",
+      "aten::embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor",
   };
   // clang-format on
 

--- a/torch/csrc/jit/tensorexpr/operators/misc.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/misc.cpp
@@ -351,6 +351,80 @@ Tensor computeChunk(
       });
 }
 
+StmtPtr computeIndirectIndexing(
+    const BufHandle& idxingTarget,
+    const BufHandle& indices,
+    size_t dimOfIndirectIdxing,
+    const std::vector<ExprHandle>& outputShape,
+    const std::function<StmtPtr(const ExprPtr&, const std::vector<ExprPtr>&)>&
+        innerStmtFunc) {
+  auto outputRank = outputShape.size();
+  auto indicesRank = indices.node()->dims().size();
+  auto dtypeIndirectIdxing =
+      idxingTarget.node()->dims().at(dimOfIndirectIdxing)->dtype();
+
+  // Generate loop-nest indices
+  std::vector<VarPtr> loopVars(outputRank);
+  std::vector<ExprPtr> loopIndices(outputRank);
+  for (size_t i = 0; i < outputRank; ++i) {
+    loopVars[i] = alloc<Var>("i_" + c10::to_string(i), outputShape[i].dtype());
+    loopIndices[i] = loopVars[i];
+  }
+
+  // Generate indirect-indexing load expr: indices[...]
+  std::vector<ExprPtr> indirectIdxLoadIndices(indicesRank);
+  for (size_t i = 0; i < indicesRank; ++i) {
+    indirectIdxLoadIndices[i] = loopIndices[i];
+  }
+  auto loadIndirectIdx = alloc<Load>(indices.node(), indirectIdxLoadIndices);
+
+  // Generate indirect-indexing var: x
+  auto indirectIdxVar = alloc<Var>("ind_idx", dtypeIndirectIdxing);
+
+  // Generate target load with indirect-indexing: idxingTarget[..., x, ...]
+  std::vector<ExprPtr> idxingTargetIndices;
+  for (size_t i = 0, idxLoopIndices = indicesRank; i < indicesRank; ++i) {
+    idxingTargetIndices.push_back(
+        (i == dimOfIndirectIdxing) ? indirectIdxVar
+                                   : loopIndices[idxLoopIndices++]);
+  }
+  auto loadIdxingTarget = alloc<Load>(idxingTarget.node(), idxingTargetIndices);
+
+  // Generate stmt for the inner-most loop body
+  StmtPtr innerStmt = innerStmtFunc(loadIdxingTarget, loopIndices);
+
+  // Generate stmt for the idxingTarget scoped loops
+  for (size_t i = outputRank; i > indicesRank; --i) {
+    innerStmt = alloc<For>(
+        loopVars[i - 1],
+        immLike(outputShape[i - 1], 0),
+        outputShape[i - 1].node(),
+        innerStmt);
+  }
+
+  // Generate stmt for the indirect-indexing: x = indices[...]
+  StmtPtr loadIndirectIdxStmt = Let::make(
+      VarHandle(indirectIdxVar),
+      promoteToDtype(
+          ExprHandle(loadIndirectIdx), dtypeIndirectIdxing.scalar_type()));
+
+  // Merge the stmts of the idxing target scoped loops and the indirect-indexing
+  auto block = alloc<tensorexpr::Block>(
+      std::vector<StmtPtr>({loadIndirectIdxStmt, innerStmt}));
+
+  // Generate stmt for the indice scoped loops
+  StmtPtr outerStmt = IRSimplifier::simplify(block);
+  for (size_t i = indicesRank; i > 0; --i) {
+    outerStmt = alloc<For>(
+        loopVars[i - 1],
+        immLike(outputShape[i - 1], 0),
+        outputShape[i - 1].node(),
+        outerStmt);
+  }
+
+  return outerStmt;
+}
+
 Tensor computeTranspose(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,
@@ -653,6 +727,38 @@ Tensor computeCat(
 }
 
 Tensor computeEmbedding(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const std::vector<ExprHandle>& outputStrides,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device) {
+  const BufHandle& idxingTarget = c10::get<BufHandle>(inputs[0]);
+  const BufHandle& indices = c10::get<BufHandle>(inputs[1]);
+  Dtype outputDtype = outputType.has_value() ? Dtype(*outputType) : kFloat;
+  BufHandle outputBuf("embedding", outputShape, outputStrides, outputDtype);
+
+  // Set the indirect-indexing param
+  size_t dimOfIndirectIdxing = 0;
+
+  StmtPtr st = computeIndirectIndexing(
+      idxingTarget,
+      indices,
+      dimOfIndirectIdxing,
+      outputShape,
+      [&](const ExprPtr& loadIdxingTarget,
+          const std::vector<ExprPtr>& loopIndices) {
+        return alloc<Store>(
+            outputBuf.node(),
+            loopIndices,
+            promoteToDtype(
+                ExprHandle(loadIdxingTarget), outputDtype.scalar_type())
+                .node());
+      });
+
+  return Tensor(outputBuf.node(), st);
+}
+
+Tensor computeEmbeddingExternalCall(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,
     const std::vector<ExprHandle>& outputStrides,

--- a/torch/csrc/jit/tensorexpr/operators/misc.h
+++ b/torch/csrc/jit/tensorexpr/operators/misc.h
@@ -42,6 +42,37 @@ ExprHandle scalarOrConstant(const ArgValue& v);
 ExprHandle broadcast(BufHandle b, const std::vector<ExprHandle>& axes);
 ExprHandle constant(const ArgValue& v);
 
+// Infrastructure to provide indirect-indexing related lowering. It helps
+// generating the overall loop-nest for the Op and indirect-indexing related
+// logic, while leaving Op-specific logic to be defined by Op with injected
+// function.
+//
+// E.x.: take a 2D indices and a 3D idxingTarget (to be indirect-indexing), and
+// the 2nd dim of idxingTarget is the dim to be indirect-indexing. The param
+// dimOfIndirectIdxing should be set to 1 (the 2nd dim). Below stmt will be
+// generated as result -
+// for i : size_i
+//   for j : size_j
+//     x = indices[i, j]
+//     for m : size_m
+//       for n : size_n
+//         innerStmt by innerStmtFunc(idxingTarget[m, x, n], [i, j, m, n])
+StmtPtr computeIndirectIndexing(
+    // Target tensor for indirect-indexing
+    const BufHandle& idxingTarget,
+    // Indices for indirect-indexing
+    const BufHandle& indices,
+    // Indirect-indexing dim of target
+    size_t dimOfIndirectIdxing,
+    // Original lowering outputShape
+    const std::vector<ExprHandle>& outputShape,
+    // OP-specific customization for inner-most loop body generation
+    const std::function<StmtPtr(
+        // Loaded IdxingTarget
+        const ExprPtr&,
+        // Loop-nest Indices
+        const std::vector<ExprPtr>&)>& innerStmtFunc);
+
 ExprHandle clamp(
     const ExprHandle& cmin,
     const ExprHandle& cmax,
@@ -87,6 +118,13 @@ Tensor computeCat(
     const c10::optional<ScalarType>& outputType,
     at::Device device);
 Tensor computeEmbedding(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const std::vector<ExprHandle>& outputStrides,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device);
+
+Tensor computeEmbeddingExternalCall(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,
     const std::vector<ExprHandle>& outputStrides,


### PR DESCRIPTION
Re-implemented embedding with native NNC IR, and rename the exsiting
external call based embedding implementation.

A new facilitation interface computeIndirectIndexing is provided to
support indirect-indexing related Ops.

