### PR TITLE
Support of conv/linear oneDNN param cache for TorchInductor

### DIFF
--- a/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
+++ b/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
@@ -40,9 +40,13 @@ TORCH_LIBRARY(mkldnn, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "mkldnn::_linear_pointwise.binary(Tensor X, Tensor other, Tensor W, Tensor? B, str attr) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "mkldnn::_convolution_pointwise(Tensor X, Tensor W, Tensor? B, int[] padding, int[] stride, int[] dilation, int groups, str attr, Scalar?[] scalars, str? algorithm) -> Tensor Y"));
+      "mkldnn::_convolution_pointwise(Tensor X, Tensor W, Tensor? B, int[] padding, int[] stride, int[] dilation, int groups, str attr, Scalar?[] scalars, str? algorithm, int param) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "mkldnn::_convolution_pointwise.binary(Tensor X, Tensor other, Tensor W, Tensor? B, int[] padding, int[] stride, int[] dilation, int groups, str attr) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "mkldnn::_conv_param_generation(Tensor X, Tensor W, Tensor? B, int[] padding, int[] stride, int[] dilation, int groups, str attr, Scalar?[] scalars, str? algorithm) -> int param"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "mkldnn::_conv_param_generation_binary(Tensor X, Tensor other, Tensor W, Tensor? B, int[] padding, int[] stride, int[] dilation, int groups, str attr) -> int param"));
 }
 
 TORCH_LIBRARY(mkldnn_prepacked, m) {

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -171,6 +171,7 @@ class WrapperCodeGen(CodeGen):
         self.prefix = IndentedBuffer()
         self.kernels = {}
         self.lines = []
+        self.onednn_param_utils_gen = False
         self.header.splice(
             f"""
                 from ctypes import c_void_p, c_long
@@ -248,6 +249,28 @@ class WrapperCodeGen(CodeGen):
         self.freed = set()
         self.write_get_cuda_stream = functools.lru_cache(None)(
             self.write_get_cuda_stream
+        )
+
+    def write_onednn_param_gen_utils(self):
+        self.header.splice(
+            f"""
+            onednn_param_cache = dict()
+            def get_onednn_conv_param(op_id, src, weight, bias, padding, stride, dilation, groups, attr, scalars, algo):
+                if op_id in onednn_param_cache:
+                    conv_param = onednn_param_cache[op_id]
+                else:
+                    conv_param = torch.ops.mkldnn._conv_param_generation(src, weight, bias, padding, stride, dilation, groups, attr, scalars, algo)
+                    onednn_param_cache[op_id] = conv_param
+                return conv_param
+            def get_onednn_conv_param_binary(op_id, src, other, weight, bias, padding, stride, dilation, groups, attr):
+                if op_id in onednn_param_cache:
+                    conv_param = onednn_param_cache[op_id]
+                else:
+                    conv_param = torch.ops.mkldnn._conv_param_generation_binary(src, other, weight, bias, padding, stride, dilation, groups, attr)
+                    onednn_param_cache[op_id] = conv_param
+                return conv_param
+
+            """
         )
 
     def write_get_cuda_stream(self, index):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -910,6 +910,7 @@ def register_onednn_fusion_ops():
             attr,
             scalars,
             algorithm,
+            param,
         ):
             return TensorBox.create(
                 ir.ConvolutionUnary.create(
@@ -923,6 +924,7 @@ def register_onednn_fusion_ops():
                     attr,
                     scalars,
                     algorithm,
+                    param,
                 )
             )
 

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -110,6 +110,7 @@ class ConvUnary2d(nn.Conv2d):
                 self.attr,
                 self.scalars,
                 self.algorithm,
+                0,
             )
         return torch.ops.mkldnn._convolution_pointwise(
             input,
@@ -122,6 +123,7 @@ class ConvUnary2d(nn.Conv2d):
             self.attr,
             self.scalars,
             self.algorithm,
+            0,
         )
 
     def forward(self, input):


### PR DESCRIPTION
This PR aims to provide oneDNN param cache support for conv/linear OPs in TorchInductor.

Additional OPs are added in pytorch to provide conv/linear param generation based on input tensors and other parameters, which will return a param handler that been stored into a param cache sitting in TorchInductor generated sub-graph code. Conv/linear OPs in the generated sub-graph code will then query the cache to get the param and use it directly instead of initializing a conv param everytime been invoked.

TorchDynamo will guard the input shape change and invoke TorchInductor to re-generate new sub-graph code which will then include a new param cache for conv/linears with new shape.

conv+unary is supported currently, while conv+binary not fully yet as that need latest ideep which is under merging.
